### PR TITLE
Print path when UnsupportedFormat error occurs

### DIFF
--- a/src/parse_man/error.rs
+++ b/src/parse_man/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
   #[error(transparent)]
   Io(#[from] std::io::Error),
 
-  #[error("Unsupported manpage format for {path:?}")]
+  #[error("Unsupported manpage format for {path}")]
   UnsupportedFormat { path: PathBuf },
 
   #[error("Could not find manpage for {cmd_name}")]

--- a/src/parse_man/error.rs
+++ b/src/parse_man/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -5,8 +7,8 @@ pub enum Error {
   #[error(transparent)]
   Io(#[from] std::io::Error),
 
-  #[error("Unsupported manpage format")]
-  UnsupportedFormat(),
+  #[error("Unsupported manpage format for {path:?}")]
+  UnsupportedFormat { path: PathBuf },
 
   #[error("Could not find manpage for {cmd_name}")]
   ManpageNotFound { cmd_name: String },

--- a/src/parse_man/mod.rs
+++ b/src/parse_man/mod.rs
@@ -56,6 +56,7 @@ pub fn get_cmd_name(manpage_path: impl AsRef<Path>) -> String {
 /// Fails if none of the manpage parsers could understand the text, or if one of
 /// them encountered an error.
 pub fn parse_manpage_text(
+  path: PathBuf,
   cmd_name: &str,
   text: impl AsRef<str>,
 ) -> Result<Vec<Flag>> {
@@ -74,7 +75,7 @@ pub fn parse_manpage_text(
   .collect::<Vec<_>>();
 
   if flags.is_empty() {
-    Err(Error::UnsupportedFormat())
+    Err(Error::UnsupportedFormat { path })
   } else {
     Ok(flags)
   }
@@ -122,11 +123,13 @@ pub fn parse_from(
   let mut errors = Vec::new();
 
   let flags = if let Some(path) = pre_info.path {
-    match read_manpage(path) {
-      Ok(text) => parse_manpage_text(cmd_name, text).unwrap_or_else(|e| {
-        errors.push(e);
-        Vec::new()
-      }),
+    match read_manpage(path.clone()) {
+      Ok(text) => {
+        parse_manpage_text(path, cmd_name, text).unwrap_or_else(|e| {
+          errors.push(e);
+          Vec::new()
+        })
+      }
       Err(e) => {
         errors.push(e.into());
         Vec::new()


### PR DESCRIPTION
It's nice to see what file couldn't be parsed, so print it when the exception occurs